### PR TITLE
Prevent window flashing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,7 @@ const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 
 let _close = 50;
-var debug = true;
+var debug = false;
 
 var _log = function(){}
 if (debug)

--- a/extension.js
+++ b/extension.js
@@ -4,7 +4,7 @@ const Mainloop = imports.mainloop;
 const Gio = imports.gi.Gio;
 
 let _close = 50;
-var debug = false;
+var debug = true;
 
 var _log = function(){}
 if (debug)
@@ -87,76 +87,81 @@ function placeWindow(loc, app) {
 	_log("placeWindow: " + loc);
 	let x, y, w, h = 0
 	var space = app.get_work_area_current_monitor()
+
+	unMaximizeIfMaximized(app);
+
 	switch (loc) {
 		case "left":
 			x = space.x;
 			y = space.y;
 			w = Math.floor(space.width/2);
 			h = space.height;
-			if (!app.maximizedVertically)
-				app.maximize(Meta.MaximizeFlags.VERTICAL)
-			if (app.maximized_horizontally)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "topleft":
 			x = space.x;
 			y = space.y;
 			w = Math.floor(space.width/2);
 			h = Math.floor(space.height/2);
-			if (app.maximized_horizontally || app.maximizedVertically)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "bottomleft":
 			x = space.x;
 			y = Math.floor(space.height/2)+space.y;
 			w = Math.floor(space.width/2);
 			h = Math.floor(space.height/2);
-			if (app.maximized_horizontally || app.maximizedVertically)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "right":
 			x = Math.floor(space.width/2+space.x);
 			y = space.y;
 			w = Math.floor(space.width/2);
 			h = space.height;
-			if (!app.maximizedVertically)
-				app.maximize(Meta.MaximizeFlags.VERTICAL)
-			if (app.maximized_horizontally)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "topright":
 			x = Math.floor(space.width/2+space.x);
 			y = space.y;
 			w = Math.floor(space.width/2);
 			h = Math.floor(space.height/2);
-			if (app.maximized_horizontally || app.maximizedVertically)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "bottomright":
 			x = Math.floor(space.width/2+space.x);
 			y = Math.floor(space.height/2)+space.y;
 			w = Math.floor(space.width/2);
 			h = Math.floor(space.height/2);
-			if (app.maximized_horizontally || app.maximizedVertically)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
-			app.move_resize_frame(true, x, y, w, h)
 			break;
 		case "maximize":
-			if (!app.maximized_horizontally || !app.maximizedVertically)
-				app.maximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+			x = space.x;
+			y = space.y;
+			w = space.width;
+			h = space.height;
 			break;
 		case "floating":
-			if (app.maximized_horizontally || app.maximizedVertically)
-				app.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+			let rect = app.originalFloatingRectangle || getDefaultFloatingRectangle(space);
+			x = rect.x;
+			y = rect.y;
+			w = rect.width;
+			h = rect.height;
 			break;
 	}
+
+	app.move_resize_frame(true, x, y, w, h);
+
 	let window = app.get_frame_rect()
 	_log("window.x: "+window.x+" window.y: "+window.y+" window.width: "+window.width+" window.height: "+window.height)
+}
+
+function unMaximizeIfMaximized(app) {
+	if (app.maximized_horizontally || app.maximized_vertically) {
+		app.unmaximize(Meta.MaximizeFlags.BOTH);
+	}
+}
+
+function getDefaultFloatingRectangle(workspace) {
+    let padding = 100;
+    return {
+        x: workspace.x + padding,
+        y: workspace.y + padding,
+        width: workspace.width - padding * 2,
+        height: workspace.height - padding * 2
+    };
 }
 
 function getMonitorArray() {
@@ -179,11 +184,17 @@ function getMonitorArray() {
 }
 
 function moveWindow(direction) {
+	_log("---");
 	_log("moveWindow: " + direction);
 	var app = global.display.focus_window;
 	var space = app.get_work_area_current_monitor()
 	let pos = getPosition(app, space);
 	_log("pos: " + pos);
+
+	if (pos == "floating") {
+		app.originalFloatingRectangle = app.get_frame_rect();
+	}
+
 	//var monitors = getMonitorArray();
 	var curMonitor = app.get_monitor();
 	let monitorToLeft = -1;


### PR DESCRIPTION
Fixes https://github.com/Fmstrat/wintile/issues/5

The basic problem is that whenever an `unMaximize` call is made, the window jumps back to its original position, and this is done before almost each move. Right before the move is executed, the window is unmaximized, and the animation of the jump has very visible flashes.

To solve this, I got rid of the maximizing approach, and went with exact resizing instead. The upside is that moving is really snappy, and there is no flashing - the downside is that there are no animations. But I think it's still a better experience.

Removing the `maximize` / `unmaximize` calls also means that moving the window to the `floating` position requires a different approach. I went with saving the window's original floating position, and restoring the window in that exact place if the `floating` move is executed. This is also how Windows implements this feature, so I think the experience is even better.