### PR TITLE
Animate preview from pointer location

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -693,10 +693,12 @@ var preview = new St.BoxLayout({
 Main.uiGroup.add_actor(preview);
 
 function showPreview(loc, _x, _y, _w, _h) {
+	if (Tweener.getTweenCount(preview) == 0) {
+		let [x, y, _] = global.get_pointer();
+		preview.x = x;
+		preview.y = y;
+	}
 	Tweener.removeTweens(preview);
-	let [x, y, _] = global.get_pointer();
-	preview.x = x;
-	preview.y = y;
 	preview.visible = true;
 	preview.loc = loc;
 	Tweener.addTween(preview, {

--- a/extension.js
+++ b/extension.js
@@ -694,6 +694,9 @@ Main.uiGroup.add_actor(preview);
 
 function showPreview(loc, _x, _y, _w, _h) {
 	Tweener.removeTweens(preview);
+	let [x, y, _] = global.get_pointer();
+	preview.x = x;
+	preview.y = y;
 	preview.visible = true;
 	preview.loc = loc;
 	Tweener.addTween(preview, {


### PR DESCRIPTION
Thank you for WinTile!

This PR tweaks how preview animations work to ensure they always start from the mouse pointer. This makes them consistent with Gnome Shell's own animations. An indirect benefit of this approach is that the preview will always animate, and not only when switching drop areas.