### PR TITLE
fix: prevent animation loop on show preview

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -744,6 +744,10 @@ function hidePreview() {
 	Tweener.removeTweens(preview);
 	preview.visible = false;
 	preview.loc = null;
+	preview.width = -1;
+	preview.height = -1;
+	preview.x = -1;
+	preview.y = -1;
 }
 
 function checkIfNearGrid(app) {

--- a/extension.js
+++ b/extension.js
@@ -720,7 +720,7 @@ var preview = new St.BoxLayout({
 Main.uiGroup.add_actor(preview);
 
 function showPreview(loc, _x, _y, _w, _h) {
-	if (Tweener.getTweenCount(preview) == 0) {
+	if (Tweener.getTweenCount(preview) == 0 && preview.x !== _x && preview.y !== _y) {
 		let [x, y, _] = global.get_pointer();
 		preview.x = x;
 		preview.y = y;


### PR DESCRIPTION
As mentioned in #66, I found that once the animation is finished `Tweener.getTweenCount(preview)` would return 0 and the preview box position in most scenarios will change and in turn it would animate the x and y pos again. Checking for x and y pos change prevents this loop.

I guess a better long term fix would be to not call `Tweener` or even the `showPreview` function if the preview area has not changed. 
 