### PR TITLE
fixes requested by gnome for v11.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
 	"description": "WinTile is a hotkey driven window tiling system for GNOME that imitates the standard Win-Arrow keys of Windows 10, allowing you to maximize, maximize to sides, or 1/4 sized to corner across a single or multiple monitors using just Super+Arrow.\n\nAs of v10, WinTile also supports:\n- 2, 3, or 4 columns for standard or ultrawide monitors\n- Top/bottom half support\n- Mouse preview and snapping for placing windows\n- 'Maximize' mode, which adds/removes GNOME animations\n- 'Ultrawide-only' mode, to limit standard screens to 2x2 while allowing ultrawides to still have 3 or 4 columns.",
 	"uuid": "wintile@nowsci.com",
 	"url": "https://github.com/fmstrat/wintile",
+	"settings-schema":"org.gnome.shell.extensions.wintile",
 	"shell-version": [
 		"3.28",
 		"3.30",
@@ -16,5 +17,5 @@
 		"43",
 		"44"
 	],
-	"version": 11
+	"version": 11.1
 }

--- a/prefs.js
+++ b/prefs.js
@@ -10,34 +10,15 @@ const Gettext = imports.gettext;
 const _ = Gettext.domain('wintile').gettext;
 
 const Config = imports.misc.config;
-const SHELL_VERSION_MAJOR = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
+const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
 
-let gschema;
-let gsettings;
 
 /**
  *
  */
 function init() {
-    gschema = Gio.SettingsSchemaSource.new_from_directory(
-        Me.dir.get_child('schemas').get_path(),
-        Gio.SettingsSchemaSource.get_default(),
-        false
-    );
-
-    gsettings = new Gio.Settings({
-        settings_schema: gschema.lookup('org.gnome.shell.extensions.wintile', true),
-    });
+    // empty
 }
-
-/**
- *
- */
-function disable() {
-    gschema = null;
-    gsettings = null;
-}
-
 
 /**
  *
@@ -53,6 +34,26 @@ function buildPrefsWidget() {
         row_spacing: 12,
         visible: true,
     });
+
+    let gsettings;
+    let gschema;
+    // Ubuntu 18.04 LTS expired in April 2023, but I'd like to support until
+    // at least 2024
+    log(`[WinTile] buildPrefsWidget SHELL_VERSION ${SHELL_VERSION}`);
+    if (SHELL_VERSION < 3.36) {
+        gschema = Gio.SettingsSchemaSource.new_from_directory(
+            Me.dir.get_child('schemas').get_path(),
+            Gio.SettingsSchemaSource.get_default(),
+            false
+        );
+
+        gsettings = new Gio.Settings({
+            settings_schema: gschema.lookup('org.gnome.shell.extensions.wintile', true),
+        });
+    } else {
+        gsettings = ExtensionUtils.getSettings();
+    }
+    layout._gsettings = gsettings;
 
     let row = 0;
 
@@ -87,7 +88,7 @@ function buildPrefsWidget() {
         visible: true,
     });
     colsSettingInt.set_value(gsettings.get_int('cols'));
-    if (SHELL_VERSION_MAJOR >= 40)
+    if (SHELL_VERSION >= 40)
         colsInput.append(colsSettingInt);
     else
         colsInput.add(colsSettingInt);
@@ -193,7 +194,7 @@ function buildPrefsWidget() {
         visible: true,
     });
     previewDistanceSettingInt.set_value(gsettings.get_int('distance'));
-    if (SHELL_VERSION_MAJOR >= 40)
+    if (SHELL_VERSION >= 40)
         previewDistanceInput.append(previewDistanceSettingInt);
     else
         previewDistanceInput.add(previewDistanceSettingInt);
@@ -223,7 +224,7 @@ function buildPrefsWidget() {
         visible: true,
     });
     previewDelaySettingInt.set_value(gsettings.get_int('delay'));
-    if (SHELL_VERSION_MAJOR >= 40)
+    if (SHELL_VERSION >= 40)
         previewDelayInput.append(previewDelaySettingInt);
     else
         previewDelayInput.add(previewDelaySettingInt);


### PR DESCRIPTION
1. Changed version checking to be float instead of int so we can deprecate < 3.36 later
1. Added settings-schema to metadata.json so ExtensionUtils.getSettings can find it 
1. Removed disable function from prefs.js
1. Made extension.js definitions consistent with prefs.js

resolves #137

@Fmstrat or @phavekes, please try this out on your gnome 3 systems