### PR TITLE
deprecated < 3.36 for v11.2

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -5,7 +5,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
 const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
 
 const {Clutter, St} = imports.gi;
 
@@ -16,7 +15,6 @@ let onWindowGrabBegin, onWindowGrabEnd;
 let requestMoveTimer, checkForMoveTimer, windowGrabBeginTimer, windowGrabEndTimer, checkIfNearGridTimer, keyManagerTimer;
 let preview;
 let windowMoving = false;
-let gschema;
 let gsettings;
 
 
@@ -1179,22 +1177,8 @@ function enable() {
     });
     Main.uiGroup.add_actor(preview);
 
-    // Ubuntu 18.04 LTS expired in April 2023, but I'd like to support until
-    // at least 2024
     log(`[WinTile] buildPrefsWidget SHELL_VERSION ${SHELL_VERSION}`);
-    if (SHELL_VERSION < 3.36) {
-        gschema = Gio.SettingsSchemaSource.new_from_directory(
-            Me.dir.get_child('schemas').get_path(),
-            Gio.SettingsSchemaSource.get_default(),
-            false
-        );
-
-        gsettings = new Gio.Settings({
-            settings_schema: gschema.lookup('org.gnome.shell.extensions.wintile', true),
-        });
-    } else {
-        gsettings = ExtensionUtils.getSettings();
-    }
+    gsettings = ExtensionUtils.getSettings();
     updateSettings();
 
     // Watch the gsettings for changes
@@ -1237,7 +1221,6 @@ function disable() {
     GLib.source_remove(windowGrabEndTimer);
     GLib.source_remove(checkIfNearGridTimer);
     GLib.source_remove(keyManagerTimer);
-    gschema = null;
     gsettings = null;
     preview = null;
 }

--- a/metadata.json
+++ b/metadata.json
@@ -5,10 +5,6 @@
 	"url": "https://github.com/fmstrat/wintile",
 	"settings-schema":"org.gnome.shell.extensions.wintile",
 	"shell-version": [
-		"3.28",
-		"3.30",
-		"3.32",
-		"3.34",
 		"3.36",
 		"3.38",
 		"40",
@@ -17,5 +13,5 @@
 		"43",
 		"44"
 	],
-	"version": 11.1
+	"version": 11.2
 }

--- a/prefs.js
+++ b/prefs.js
@@ -16,13 +16,6 @@ const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
 /**
  *
  */
-function init() {
-    // empty
-}
-
-/**
- *
- */
 function buildPrefsWidget() {
     // Create a parent widget that we'll return from this function
     let layout = new Gtk.Grid({
@@ -36,23 +29,7 @@ function buildPrefsWidget() {
     });
 
     let gsettings;
-    let gschema;
-    // Ubuntu 18.04 LTS expired in April 2023, but I'd like to support until
-    // at least 2024
-    log(`[WinTile] buildPrefsWidget SHELL_VERSION ${SHELL_VERSION}`);
-    if (SHELL_VERSION < 3.36) {
-        gschema = Gio.SettingsSchemaSource.new_from_directory(
-            Me.dir.get_child('schemas').get_path(),
-            Gio.SettingsSchemaSource.get_default(),
-            false
-        );
-
-        gsettings = new Gio.Settings({
-            settings_schema: gschema.lookup('org.gnome.shell.extensions.wintile', true),
-        });
-    } else {
-        gsettings = ExtensionUtils.getSettings();
-    }
+    gsettings = ExtensionUtils.getSettings();
     layout._gsettings = gsettings;
 
     let row = 0;


### PR DESCRIPTION
Ubuntu 18.04LTS (3.34) stopped receiving support in April 2023. Gnome.org has asked we remove support for all shells before 3.36
