### PR TITLE
Ctrl+Super resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ There are a few zones to be aware of
     - If using 4/5 columns and double-width is enabled, it will maximize on that half of the screen
 
 - Holding `<CTRL>` while dragging will create a 1x1 anywhere in the grid without needing to be at an edge
+- Holding `<SUPER>`+`<CTRL>` will create a start point for multi-row/col tiles
 - Any other zone along the edge will create a 1x1 tile
 
 


### PR DESCRIPTION
While dragging a tile, holding `<CTRL>` and `<SUPER>` will create a start point for a preview.  Now you can drag a window to be X cols wide by Y rows tall