### PR TITLE
Update keybindings.js

### DIFF
--- a/keybindings.js
+++ b/keybindings.js
@@ -1,7 +1,6 @@
 'use strict';
 /* global global */
 
-const Config = imports.misc.config;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;

--- a/keybindings.js
+++ b/keybindings.js
@@ -6,8 +6,6 @@ const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 
-const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
-
 /**
  * Keybindings.Manager is a simple convenience class for managing keyboard
  * shortcuts in GNOME Shell. You bind a shortcut using add(), which on success
@@ -53,13 +51,7 @@ var Manager = class Manager {
      */
     add(accelerator, callback) {
         let action = Meta.KeyBindingAction.NONE;
-
-        // A flags argument was added somewhere between 3.30-3.32
-        if (SHELL_VERSION < 3.30)
-            action = global.display.grab_accelerator(accelerator);
-        else
-            action = global.display.grab_accelerator(accelerator, 0);
-
+        action = global.display.grab_accelerator(accelerator, 0);
 
         if (action !== Meta.KeyBindingAction.NONE) {
             let name = Meta.external_binding_name_for_action(action);


### PR DESCRIPTION
Remove 3.30-3.32 shell validation

Per EGO request

(don't increment version number) 