### PR TITLE
Porting to GNOME 45

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 rm wintile@nowsci.com.zip
 glib-compile-schemas schemas/
-zip -r9 wintile@nowsci.com.zip extension.js keybindings.js metadata.json prefs.js schemas
+zip -r9 wintile@nowsci.com.zip extension.js keybindings.js settings.ui metadata.json prefs.js schemas

--- a/extension.js
+++ b/extension.js
@@ -1,27 +1,28 @@
 /* global global */
 
 /* BEGIN NON-G45 */
-const Meta = imports.gi.Meta;
-const Main = imports.ui.main;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Clutter = imports.gi.Clutter;
-const St = imports.gi.St;
-const Config = imports.misc.config;
-const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
+// const Meta = imports.gi.Meta;
+// const Main = imports.ui.main;
+// const Gio = imports.gi.Gio;
+// const GLib = imports.gi.GLib;
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Clutter = imports.gi.Clutter;
+// const St = imports.gi.St;
+// const Config = imports.misc.config;
+// const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
 /* END NON-G45 */
 
 /* BEGIN G45 */
-// import Meta from 'gi://Meta';
-// import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// import Gio from 'gi://Gio';
-// import GLib from 'gi://GLib';
-// import Extension from 'resource:///org/gnome/shell/extensions/extension.js';
-// import Clutter from 'gi://Clutter';
-// import St from 'gi://St';
-// import Config from imports.misc.config;
-// const SHELL_VERSION = parseFloat(Config.PACKAGE_VERSION);
+import Meta from 'gi://Meta';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import { Extension }from 'resource:///org/gnome/shell/extensions/extension.js';
+import Clutter from 'gi://Clutter';
+import St from 'gi://St';
+import { PACKAGE_VERSION } from 'resource:///org/gnome/shell/misc/config.js';
+import KeyBindingsManager from './keybindings.js';
+const SHELL_VERSION = parseFloat(PACKAGE_VERSION);
 /* END G45 */
 
 let onWindowGrabBegin, onWindowGrabEnd;
@@ -82,13 +83,16 @@ function updateSettings() {
     _log(JSON.stringify(config));
 }
 
-const wintile = {
-    extdatadir: imports.misc.extensionUtils.getCurrentExtension().path,
-    shell_version: parseInt(Config.PACKAGE_VERSION.split('.')[1], 10),
-};
-imports.searchPath.unshift(wintile.extdatadir);
+/* BEGIN NON-G45 */
+// const wintile = {
+//     extdatadir: imports.misc.extensionUtils.getCurrentExtension().path,
+//     shell_version: parseInt(Config.PACKAGE_VERSION.split('.')[1], 10),
+// };
+// imports.searchPath.unshift(wintile.extdatadir); 
 
-const KeyBindings = imports.keybindings;
+// const KeyBindings = imports.keybindings; 
+/* END NON-G45 */
+
 let keyManager = null;
 var oldbindings = {
     unmaximize: [],
@@ -1068,10 +1072,24 @@ function getMonitorInfo(monitorIndex) {
 /**
  *
  */
-class WintileExtension {
+
+/* BEGIN NON-G45 */
+// class WintileExtension {
+/* END NON-G45 */
+
+/* BEGIN G45 */
+export default class WintileExtension extends Extension {
+/* END G45 */
     enable() {
         _log('enable) Keymanager is being defined');
-        keyManager = new KeyBindings.Manager();
+
+        /* BEGIN G45 */
+        keyManager = new KeyBindingsManager();
+        /* END G45 */
+
+        /* BEGIN NON-G45 */
+        // keyManager = new KeyBindings.Manager();
+        /* END NON-G45 */
         let desktopSettings = new Gio.Settings({schema_id: 'org.gnome.desktop.wm.keybindings'});
         let mutterKeybindingSettings = new Gio.Settings({schema_id: 'org.gnome.mutter.keybindings'});
         let mutterSettings = new Gio.Settings({schema_id: 'org.gnome.mutter'});
@@ -1139,7 +1157,13 @@ class WintileExtension {
         });
         Main.uiGroup.add_actor(preview);
 
-        gsettings = ExtensionUtils.getSettings();
+        /* BEGIN G45 */
+        gsettings = this.getSettings();
+        /* END G45 */
+
+        /* BEGIN NON-G45 */
+        // gsettings = ExtensionUtils.getSettings();
+        /* END NON-G45 */
         updateSettings();
 
         // Watch the gsettings for changes
@@ -1187,10 +1211,12 @@ class WintileExtension {
     }
 }
 
-/**
- *
- * @param {object} _meta = standard meta object
- */
-function init(_meta) {
-    return new WintileExtension();
-}
+/* BEGIN NON-G45 */
+// /**
+//  *
+//  * @param {object} _meta = standard meta object
+//  */
+// function init(_meta) {
+//     return new WintileExtension();
+// }
+/* END NON-G45 */

--- a/extension.js
+++ b/extension.js
@@ -17,10 +17,10 @@ import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-import { Extension }from 'resource:///org/gnome/shell/extensions/extension.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import Clutter from 'gi://Clutter';
 import St from 'gi://St';
-import { PACKAGE_VERSION } from 'resource:///org/gnome/shell/misc/config.js';
+import {PACKAGE_VERSION} from 'resource:///org/gnome/shell/misc/config.js';
 import KeyBindingsManager from './keybindings.js';
 const SHELL_VERSION = parseFloat(PACKAGE_VERSION);
 /* END G45 */
@@ -88,9 +88,9 @@ function updateSettings() {
 //     extdatadir: imports.misc.extensionUtils.getCurrentExtension().path,
 //     shell_version: parseInt(Config.PACKAGE_VERSION.split('.')[1], 10),
 // };
-// imports.searchPath.unshift(wintile.extdatadir); 
+// imports.searchPath.unshift(wintile.extdatadir);
 
-// const KeyBindings = imports.keybindings; 
+// const KeyBindings = imports.keybindings;
 /* END NON-G45 */
 
 let keyManager = null;

--- a/keybindings.js
+++ b/keybindings.js
@@ -1,9 +1,17 @@
 'use strict';
 /* global global */
 
-const Main = imports.ui.main;
-const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
+/* BEGIN NON-G45 */
+// const Main = imports.ui.main;
+// const Meta = imports.gi.Meta;
+// const Shell = imports.gi.Shell;
+/* END NON-G45 */
+
+/* BEGIN G45 */
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import Meta from "gi://Meta";
+import Shell from "gi://Shell";
+/* END G45 */ 
 
 /**
  * Keybindings.Manager is a simple convenience class for managing keyboard
@@ -20,7 +28,12 @@ const Shell = imports.gi.Shell;
  *     https://developer.gnome.org/meta/stable/meta-MetaKeybinding.html
  *     https://gitlab.gnome.org/GNOME/gnome-shell/blob/master/js/ui/windowManager.js#L1093-1112
  */
-var Manager = class Manager {
+/* BEGIN NON-G45 */
+// var Manager = class Manager {
+/* END NON-G45 */
+/* BEGIN G45 */
+export default class KeyBindingsManager {
+/* END G45 */
     constructor() {
         this._keybindings = new Map();
 

--- a/keybindings.js
+++ b/keybindings.js
@@ -9,9 +9,9 @@
 
 /* BEGIN G45 */
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import Meta from "gi://Meta";
-import Shell from "gi://Shell";
-/* END G45 */ 
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+/* END G45 */
 
 /**
  * Keybindings.Manager is a simple convenience class for managing keyboard
@@ -107,5 +107,5 @@ export default class KeyBindingsManager {
         global.display.disconnect(this._acceleratorActivatedId);
         this.removeAll();
     }
-};
+}
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,11 @@
 {
 	"name": "WinTile",
-	"description": "WinTile is a hotkey driven window tiling system for GNOME that imitates the standard Win-Arrow keys of Windows 10, allowing you to maximize, maximize to sides, or 1/4 sized to corner across a single or multiple monitors using just Super+Arrow.\n\nAs of v16, WinTile also supports:\n- 1-5 columns and 1-5 rows for standard or ultrawide monitors\n- Top/bottom half support\n- Mouse preview and snapping for placing windows\n- 'Maximize' mode, which adds/removes GNOME animations\n- 'Ultrawide-only' mode, to allow standard screens to have different cols/row than ultrawides\n- Portrait screens will automatically swap columns and rows\n- Add gaps around tiles to avoid the 'crowded elevator' feeling'\n- Ctrl+Super+Arrow to grow a tile in that direction if space is available\n- Ctrl+drag to drop a tile in a specific spot\n- Ctrl+Super+drag to draw a grid for the new tile",
+	"description": "WinTile is a hotkey driven window tiling system for GNOME that imitates the standard Win-Arrow keys of Windows 10, allowing you to maximize, maximize to sides, or 1/4 sized to corner across a single or multiple monitors using just Super+Arrow.\n\nAs of v17, WinTile also supports:\n- 1-5 columns and 1-5 rows for standard or ultrawide monitors\n- Top/bottom half support\n- Mouse preview and snapping for placing windows\n- 'Maximize' mode, which adds/removes GNOME animations\n- 'Ultrawide-only' mode, to allow standard screens to have different cols/row than ultrawides\n- Portrait screens will automatically swap columns and rows\n- Add gaps around tiles to avoid the 'crowded elevator' feeling'\n- Ctrl+Super+Arrow to grow a tile in that direction if space is available\n- Ctrl+drag to drop a tile in a specific spot\n- Ctrl+Super+drag to draw a grid for the new tile",
 	"uuid": "wintile@nowsci.com",
 	"url": "https://github.com/fmstrat/wintile",
 	"settings-schema":"org.gnome.shell.extensions.wintile",
 	"shell-version": [
-		"42",
-		"43",
-		"44"
+		"45"
 	],
 	"version": 17
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,81 +1,96 @@
 'use strict';
 
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
+/* BEGIN NON-G45 */
+// const Gio = imports.gi.Gio;
+// const Gtk = imports.gi.Gtk;
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Me = ExtensionUtils.getCurrentExtension();
 
-const Gettext = imports.gettext;
-const _ = Gettext.domain('wintile').gettext;
+// const Gettext = imports.gettext;
+// const _ = Gettext.domain('wintile').gettext;
 
-const gsettings = ExtensionUtils.getSettings();
+// const gsettings = ExtensionUtils.getSettings();
 
-/**
- *
- */
-function init() {
-    // empty
-}
+// /**
+//  *
+//  */
+// function init() {
+//     // empty
+// } 
+/* END NON-G45 */ 
 
+/* BEGIN G45 */
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-/**
- *
- * @param {object} window - Don't worry about this. Gnome handles it for you.
- */
-function fillPreferencesWindow(window) {
-    let builder = Gtk.Builder.new();
-    builder.add_from_file(`${Me.path}/settings.ui`);
-    let gridPage = builder.get_object('gridPage');
-    let behaviorPage = builder.get_object('behaviorPage');
-    window.add(gridPage);
-    window.add(behaviorPage);
+export default class WinTileExtensionPreferences extends ExtensionPreferences {
+/* END G45 */
+    /**
+     *
+     * @param {object} window - Don't worry about this. Gnome handles it for you.
+     */
+    /* BEGIN G45 */
+    fillPreferencesWindow(window) {
+    /* END G45 */
+    /* BEGIN NON-G45 */
+    // function fillPreferencesWindow(window) {
+    /* END NON-G45 */
+        let builder = Gtk.Builder.new();
+        builder.add_from_file(`${this.path}/settings.ui`);
+        let gridPage = builder.get_object('gridPage');
+        let behaviorPage = builder.get_object('behaviorPage');
+        window.add(gridPage);
+        window.add(behaviorPage);
 
-    //    let gsettings;
-    //    gsettings = ExtensionUtils.getSettings();
-    const bindSettings = (key, input) => {
-        key.value = gsettings.get_value(input).deep_unpack();
-        gsettings.bind(input, key, 'active', Gio.SettingsBindFlags.DEFAULT);
-    };
+        /* BEGIN G45 */
+        let gsettings = this.getSettings()
+        /* END G45 */
+        const bindSettings = (key, input) => {
+            key.value = gsettings.get_value(input).deep_unpack();
+            gsettings.bind(input, key, 'active', Gio.SettingsBindFlags.DEFAULT);
+        };
 
-    const connectAndSetInt = (key, input) => {
-        key.value = gsettings.get_value(input).deep_unpack();
-        key.connect('value-changed', entry => {
-            gsettings.set_int(input, entry.value);
-        });
-    };
+        const connectAndSetInt = (key, input) => {
+            key.value = gsettings.get_value(input).deep_unpack();
+            key.connect('value-changed', entry => {
+                gsettings.set_int(input, entry.value);
+            });
+        };
 
-    let ultrawideOnlyInput = builder.get_object('ultrawideOnlyInput');
-    let nonUltrawideGroup = builder.get_object('nonUltrawideGroup');
+        let ultrawideOnlyInput = builder.get_object('ultrawideOnlyInput');
+        let nonUltrawideGroup = builder.get_object('nonUltrawideGroup');
 
-    const toggleUltrawide = () => {
-        if (ultrawideOnlyInput.active) {
-            // Show rows and columns options
-            nonUltrawideGroup.show();
-        } else {
-            // Hide rows and columns options
-            nonUltrawideGroup.hide();
-        }
-    };
+        const toggleUltrawide = () => {
+            if (ultrawideOnlyInput.active) {
+                // Show rows and columns options
+                nonUltrawideGroup.show();
+            } else {
+                // Hide rows and columns options
+                nonUltrawideGroup.hide();
+            }
+        };
 
-    // settings that aren't toggles need a connect
-    connectAndSetInt(builder.get_object('colsSettingInt'), 'cols');
-    connectAndSetInt(builder.get_object('rowsSettingInt'), 'rows');
-    connectAndSetInt(builder.get_object('nonUltraColsSettingInt'), 'non-ultra-cols');
-    connectAndSetInt(builder.get_object('nonUltraRowsSettingInt'), 'non-ultra-rows');
-    connectAndSetInt(builder.get_object('previewDistanceSettingInt'), 'distance');
-    connectAndSetInt(builder.get_object('previewDelaySettingInt'), 'delay');
-    connectAndSetInt(builder.get_object('gapSettingInt'), 'gap');
+        // settings that aren't toggles need a connect
+        connectAndSetInt(builder.get_object('colsSettingInt'), 'cols');
+        connectAndSetInt(builder.get_object('rowsSettingInt'), 'rows');
+        connectAndSetInt(builder.get_object('nonUltraColsSettingInt'), 'non-ultra-cols');
+        connectAndSetInt(builder.get_object('nonUltraRowsSettingInt'), 'non-ultra-rows');
+        connectAndSetInt(builder.get_object('previewDistanceSettingInt'), 'distance');
+        connectAndSetInt(builder.get_object('previewDelaySettingInt'), 'delay');
+        connectAndSetInt(builder.get_object('gapSettingInt'), 'gap');
 
-    // all other settings need a bind
-    bindSettings(builder.get_object('ultrawideOnlyInput'), 'ultrawide-only');
-    bindSettings(builder.get_object('maximizeInput'), 'use-maximize');
-    bindSettings(builder.get_object('minimizeInput'), 'use-minimize');
-    bindSettings(builder.get_object('previewInput'), 'preview');
-    bindSettings(builder.get_object('doubleWidthInput'), 'double-width');
-    bindSettings(builder.get_object('debugInput'), 'debug');
-    ultrawideOnlyInput.connect('notify::active', toggleUltrawide);
+        // all other settings need a bind
+        bindSettings(builder.get_object('ultrawideOnlyInput'), 'ultrawide-only');
+        bindSettings(builder.get_object('maximizeInput'), 'use-maximize');
+        bindSettings(builder.get_object('minimizeInput'), 'use-minimize');
+        bindSettings(builder.get_object('previewInput'), 'preview');
+        bindSettings(builder.get_object('doubleWidthInput'), 'double-width');
+        bindSettings(builder.get_object('debugInput'), 'debug');
+        ultrawideOnlyInput.connect('notify::active', toggleUltrawide);
 
-    // make sure that the non-ultrawide menu is hidden unless it's enabled
-    toggleUltrawide();
+        // make sure that the non-ultrawide menu is hidden unless it's enabled
+        toggleUltrawide();
+    }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -17,13 +17,13 @@
 //  */
 // function init() {
 //     // empty
-// } 
-/* END NON-G45 */ 
+// }
+/* END NON-G45 */
 
 /* BEGIN G45 */
 import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
-import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class WinTileExtensionPreferences extends ExtensionPreferences {
 /* END G45 */
@@ -45,7 +45,7 @@ export default class WinTileExtensionPreferences extends ExtensionPreferences {
         window.add(behaviorPage);
 
         /* BEGIN G45 */
-        let gsettings = this.getSettings()
+        let gsettings = this.getSettings();
         /* END G45 */
         const bindSettings = (key, input) => {
             key.value = gsettings.get_value(input).deep_unpack();


### PR DESCRIPTION
This PR works fine on my fedora 39 with GNOME 45. It has code for both Gnome 45 and versions before with comments showing which sections work for which version. The code for the older version is commented out. This was based on this comment by @GrylledCheez in https://github.com/Fmstrat/wintile/issues/165#issuecomment-1763581358_
 
I also added settings.ui to the build package which was not included in build.sh script before.