### PR TITLE
fix: make compatible with gnome 46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-wintile@nowsci.com.zip
+# node.js stuff
 node_modules/
 package-lock.json
 package.json
+
+# compiled output
+wintile@nowsci.com
+wintile@nowsci.com.zip

--- a/extension.js
+++ b/extension.js
@@ -1155,7 +1155,7 @@ export default class WintileExtension extends Extension {
             style_class: 'tile-preview',
             visible: false,
         });
-        Main.uiGroup.add_actor(preview);
+        Main.uiGroup.add_child(preview);
 
         /* BEGIN G45 */
         gsettings = this.getSettings();

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
 	"url": "https://github.com/fmstrat/wintile",
 	"settings-schema":"org.gnome.shell.extensions.wintile",
 	"shell-version": [
-		"45"
+		"46"
 	],
 	"version": 17
 }


### PR DESCRIPTION
This is a minimal fix to make the extension compatible with gnome 46